### PR TITLE
Guard examples and tests against missing Suggested packages

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,7 @@ Imports:
 License: GPL (>= 3)
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.2.1
+RoxygenNote: 7.3.3
 Roxygen: list(markdown = TRUE)
 Suggests: 
     dplyr,

--- a/R/connect.R
+++ b/R/connect.R
@@ -48,7 +48,7 @@ assign("defaults",
 #'
 #' @returns `NULL`, invisibly
 #' @export
-#' @examples
+#' @examplesIf requireNamespace("RSQLite", quietly = TRUE)
 #' library(sqlhelper)
 #'
 #' example_filename <- system.file("examples",

--- a/R/connection_info.R
+++ b/R/connection_info.R
@@ -25,7 +25,7 @@
 #' connections have been configured (e.g. `connect()` has not been called),
 #' `NULL` is returned.
 #'
-#' @examples
+#' @examplesIf requireNamespace("RSQLite", quietly = TRUE)
 #' library(sqlhelper)
 #'
 #' connect(

--- a/R/default_conn.R
+++ b/R/default_conn.R
@@ -5,7 +5,7 @@
 #' @return A database connection returned by `DBI::dbConnect()` or
 #'   `pool::dbPool()`
 #'
-#' @examples
+#' @examplesIf requireNamespace("RSQLite", quietly = TRUE)
 #' library(sqlhelper)
 #'
 #' connect(

--- a/R/disconnect.R
+++ b/R/disconnect.R
@@ -1,7 +1,7 @@
 #' Close all connections and remove them from the connections cache
 #'
 #' @return `NULL`, invisibly
-#' @examples
+#' @examplesIf requireNamespace("RSQLite", quietly = TRUE)
 #' library(sqlhelper)
 #' connect(
 #'   system.file("examples",

--- a/R/is_connected.R
+++ b/R/is_connected.R
@@ -6,7 +6,7 @@
 #' @return Logical, or NULL if `conn_name` does not identify exactly 1
 #' connection
 #'
-#' @examples
+#' @examplesIf requireNamespace("RSQLite", quietly = TRUE)
 #' library(sqlhelper)
 #'
 #' connect(

--- a/R/live_connection.R
+++ b/R/live_connection.R
@@ -6,7 +6,7 @@
 #' @return A live connection to a database, or NULL, invisibly, if
 #'   `conn_name` is not the name of a live connection
 #'
-#' @examples
+#' @examplesIf requireNamespace("RSQLite", quietly = TRUE)
 #' library(sqlhelper)
 #' connect(
 #'   system.file("examples/sqlhelper_db_conf.yml",

--- a/R/prepare_sql.R
+++ b/R/prepare_sql.R
@@ -56,7 +56,7 @@
 #'   to be executed, i.e. with interpolations and quoting in place}
 #'   }
 #'
-#' @examples
+#' @examplesIf requireNamespace("RSQLite", quietly = TRUE)
 #' library(sqlhelper)
 #' connect(
 #'     system.file("examples/sqlhelper_db_conf.yml",

--- a/R/set_default_conn_name.R
+++ b/R/set_default_conn_name.R
@@ -5,7 +5,7 @@
 #' @return \code{get} returns the name of the default connection;
 #'      \code{set} returns \code{NULL}, invisibly.
 #'
-#' @examples
+#' @examplesIf requireNamespace("RSQLite", quietly = TRUE)
 #' library(sqlhelper)
 #' connect(
 #'     system.file("examples/sqlhelper_db_conf.yml",

--- a/R/sqlrunners.R
+++ b/R/sqlrunners.R
@@ -50,7 +50,7 @@
 #'  \item{result}{The result of the query}
 #' }
 #'
-#' @examples
+#' @examplesIf requireNamespace("RSQLite", quietly = TRUE)
 #' library(sqlhelper)
 #'
 #' readLines(
@@ -259,7 +259,7 @@ runqueries <- run_queries
 #' meaning that if you want to use the same values throughout, you need only set
 #' them for the first query. See `read_sql()` for details.
 #'
-#' @examples
+#' @examplesIf requireNamespace("RSQLite", quietly = TRUE) && requireNamespace("spData", quietly = TRUE)
 #' library(sqlhelper)
 #'
 #' config_filename <- system.file("examples/sqlhelper_db_conf.yml",

--- a/man/config_examples.Rd
+++ b/man/config_examples.Rd
@@ -10,15 +10,14 @@ config_examples(filename = NA)
 \item{filename}{A string. If supplied, examples are written to a file with this name.}
 }
 \value{
-A yaml string of database configuration examples, invisibly.
+A yaml string of database configuration examples.
 }
 \description{
 Provides example configurations for several databases and a range of options
 }
 \details{
 Irrespective of whether a filename is supplied, yaml configuration examples
-will be returned invisibly as a single string and printed if the session is
-interactive.
+will be returned as a single string.
 }
 \examples{
 config_examples()

--- a/man/connect.Rd
+++ b/man/connect.Rd
@@ -51,6 +51,7 @@ connections in those files are invalid)
 config file and how to access the created connections.
 }
 \examples{
+\dontshow{if (requireNamespace("RSQLite", quietly = TRUE)) withAutoprint(\{ # examplesIf}
 library(sqlhelper)
 
 example_filename <- system.file("examples",
@@ -63,5 +64,5 @@ connect(example_filename)
 
 # Read only the named example file
 connect(example_filename, exclusive=TRUE)
-
+\dontshow{\}) # examplesIf}
 }

--- a/man/connection_info.Rd
+++ b/man/connection_info.Rd
@@ -36,6 +36,7 @@ connections have been configured (e.g. \code{connect()} has not been called),
 Provides information about created connections.
 }
 \examples{
+\dontshow{if (requireNamespace("RSQLite", quietly = TRUE)) withAutoprint(\{ # examplesIf}
 library(sqlhelper)
 
 connect(
@@ -49,5 +50,5 @@ connect(
  connection_info()
 
  connection_info("pool_sqlite")
-
+\dontshow{\}) # examplesIf}
 }

--- a/man/default_conn.Rd
+++ b/man/default_conn.Rd
@@ -14,6 +14,7 @@ A database connection returned by \code{DBI::dbConnect()} or
 A convenience wrapper around \code{live_connection()} and \code{get_default_conn_name()}
 }
 \examples{
+\dontshow{if (requireNamespace("RSQLite", quietly = TRUE)) withAutoprint(\{ # examplesIf}
 library(sqlhelper)
 
 connect(
@@ -25,4 +26,5 @@ connect(
    )
 
 default_conn()
+\dontshow{\}) # examplesIf}
 }

--- a/man/disconnect.Rd
+++ b/man/disconnect.Rd
@@ -13,6 +13,7 @@ disconnect()
 Close all connections and remove them from the connections cache
 }
 \examples{
+\dontshow{if (requireNamespace("RSQLite", quietly = TRUE)) withAutoprint(\{ # examplesIf}
 library(sqlhelper)
 connect(
   system.file("examples",
@@ -20,4 +21,5 @@ connect(
               package="sqlhelper")
 )
 disconnect()
+\dontshow{\}) # examplesIf}
 }

--- a/man/is_connected.Rd
+++ b/man/is_connected.Rd
@@ -21,6 +21,7 @@ connection
 Test whether a database is connected
 }
 \examples{
+\dontshow{if (requireNamespace("RSQLite", quietly = TRUE)) withAutoprint(\{ # examplesIf}
 library(sqlhelper)
 
 connect(
@@ -37,4 +38,5 @@ not_connected("simple_sqlite")
 disconnect()
 is_connected("simple_sqlite")
 not_connected("simple_sqlite")
+\dontshow{\}) # examplesIf}
 }

--- a/man/live_connection.Rd
+++ b/man/live_connection.Rd
@@ -18,6 +18,7 @@ A live connection to a database, or NULL, invisibly, if
 Return the named connection or NULL
 }
 \examples{
+\dontshow{if (requireNamespace("RSQLite", quietly = TRUE)) withAutoprint(\{ # examplesIf}
 library(sqlhelper)
 connect(
   system.file("examples/sqlhelper_db_conf.yml",
@@ -31,5 +32,5 @@ conn
 DBI::dbDisconnect(conn)
 is.null(live_connection("simple_sqlite"))
 is.null(live_connection("foo"))
-
+\dontshow{\}) # examplesIf}
 }

--- a/man/prepare_sql.Rd
+++ b/man/prepare_sql.Rd
@@ -74,6 +74,7 @@ is not a configured sqlhelper connection which can then be used to
 interpolate quoted strings.
 }
 \examples{
+\dontshow{if (requireNamespace("RSQLite", quietly = TRUE)) withAutoprint(\{ # examplesIf}
 library(sqlhelper)
 connect(
     system.file("examples/sqlhelper_db_conf.yml",
@@ -86,5 +87,5 @@ foo <- 'bar'
 prepped <- prepare_sql(c("select {`foo`}", "select {n}"))
 prepped
 prepped$prepared_sql
-
+\dontshow{\}) # examplesIf}
 }

--- a/man/run_files.Rd
+++ b/man/run_files.Rd
@@ -66,6 +66,7 @@ meaning that if you want to use the same values throughout, you need only set
 them for the first query. See \code{read_sql()} for details.
 }
 \examples{
+\dontshow{if (requireNamespace("RSQLite", quietly = TRUE) && requireNamespace("spData", quietly = TRUE)) withAutoprint(\{ # examplesIf}
 library(sqlhelper)
 
 config_filename <- system.file("examples/sqlhelper_db_conf.yml",
@@ -99,7 +100,7 @@ results$n_longest_setosa_petal_lengths
 
 plot(results$get_congruent, border = "orange")
 plot(results$get_incongruent, border = "blue", add=TRUE)
-
+\dontshow{\}) # examplesIf}
 }
 \seealso{
 \code{\link[=read_sql]{read_sql()}}, \code{\link[=prepare_sql]{prepare_sql()}}

--- a/man/run_queries.Rd
+++ b/man/run_queries.Rd
@@ -65,6 +65,7 @@ will be raised. See \code{vignette("connections")} for details about the
 configuration search path.
 }
 \examples{
+\dontshow{if (requireNamespace("RSQLite", quietly = TRUE)) withAutoprint(\{ # examplesIf}
 library(sqlhelper)
 
 readLines(
@@ -110,7 +111,7 @@ run_queries("create table iris_setosa as select * from iris where species = 'set
           execmethod = 'execute')
 
 run_queries("select distinct species as species from iris_setosa")
-
+\dontshow{\}) # examplesIf}
 }
 \seealso{
 \code{\link[=read_sql]{read_sql()}}, \code{\link[=prepare_sql]{prepare_sql()}}

--- a/man/set_default_conn_name.Rd
+++ b/man/set_default_conn_name.Rd
@@ -20,6 +20,7 @@ get_default_conn_name()
 Set/get the name of the default connection to use
 }
 \examples{
+\dontshow{if (requireNamespace("RSQLite", quietly = TRUE)) withAutoprint(\{ # examplesIf}
 library(sqlhelper)
 connect(
     system.file("examples/sqlhelper_db_conf.yml",
@@ -36,5 +37,5 @@ set_default_conn_name("pool_sqlite")
 connection_info()
 
 get_default_conn_name()
-
+\dontshow{\}) # examplesIf}
 }

--- a/tests/testthat/test-connect.R
+++ b/tests/testthat/test-connect.R
@@ -1,6 +1,7 @@
 
 
 test_that("connections can be added and discovered",{
+  skip_if_not_installed("RSQLite")
   expect_null(connection_info())
 
   connect(config_filename = testthat::test_path("testfiles",
@@ -18,6 +19,7 @@ test_that("connections can be added and discovered",{
 })
 
 test_that("live_connection returns invisible nulls as expected",{
+  skip_if_not_installed("RSQLite")
   expect_null(
     live_connection("foo")
   )
@@ -30,6 +32,7 @@ test_that("live_connection returns invisible nulls as expected",{
 })
 
 test_that("default_conn returns the expected connection", {
+  skip_if_not_installed("RSQLite")
 
   defcon1 <- default_conn()
   defcon2 <- get_default_conn_name() |> live_connection()
@@ -38,6 +41,7 @@ test_that("default_conn returns the expected connection", {
 })
 
 test_that("pruning an unnamed connection raises the right error",{
+  skip_if_not_installed("RSQLite")
   expect_error(
     sqlhelper:::prune("foo"),
     "No connection named foo"
@@ -45,6 +49,7 @@ test_that("pruning an unnamed connection raises the right error",{
 })
 
 test_that("connections can be closed",{
+  skip_if_not_installed("RSQLite")
   expect_equal(connection_info()$name,
                c("single_mem2","single_mem","pool_mem","sqlite_dbi"))
   disconnect()
@@ -52,6 +57,7 @@ test_that("connections can be closed",{
 })
 
 test_that("messages and warnings are raised on failure", {
+  skip_if_not_installed("RSQLite")
   expect_message(
     suppressWarnings(
       connect(config_filename = testthat::test_path("testfiles",

--- a/tests/testthat/test-is_connected.R
+++ b/tests/testthat/test-is_connected.R
@@ -1,5 +1,6 @@
 
 test_that("is_connected returns an appropriate value", {
+  skip_if_not_installed("RSQLite")
   connect(config_filename = testthat::test_path("testfiles",
                                                 "sqlhelper_db_conf.yml"),
           exclusive=TRUE)
@@ -17,6 +18,7 @@ test_that("is_connected returns an appropriate value", {
 })
 
 test_that("not_connected returns an appropriate value", {
+  skip_if_not_installed("RSQLite")
   connect(config_filename = testthat::test_path("testfiles",
                                                 "sqlhelper_db_conf.yml"),
           exclusive=TRUE)

--- a/tests/testthat/test-prepare_sql.R
+++ b/tests/testthat/test-prepare_sql.R
@@ -1,5 +1,6 @@
 # Check names of lists are properly transferred
 test_that("names are preserved", {
+  skip_if_not_installed("RSQLite")
   connect(config_filename = testthat::test_path("testfiles",
                                                 "sqlhelper_db_conf.yml"),
           exclusive=TRUE)
@@ -10,6 +11,7 @@ test_that("names are preserved", {
 
 # Check errors are raised for improperly formed inputs (wrong cols, wrong rows)
 test_that("inputs are validated", {
+  skip_if_not_installed("RSQLite")
   expect_error(prepare_sql(tibble::tibble(a=c(1,2),b=c(3,4))), "must have these columns")
   expect_error(prepare_sql(list(one="SELECT 1", two="SELECT2")), "must be a character vector or a tibble")
   expect_error(prepare_sql(c(one=1, two=2)), "must be a character vector or a tibble")
@@ -88,6 +90,7 @@ test_that("inputs are validated", {
 
 # Check that only NAs are replaced with defaults (and that they are properly replaced)
 test_that("NAs are replaced by defaults", {
+  skip_if_not_installed("RSQLite")
   n <- 5
   foo <- "bar"
   sql <- read_sql( testthat::test_path( "testfiles", "test_prepare.SQL")) |>
@@ -118,6 +121,7 @@ test_that("NAs are replaced by defaults", {
 
 # Check interpolations
 test_that("defaults are properly set", {
+  skip_if_not_installed("RSQLite")
   connect(config_filename = testthat::test_path("testfiles",
                                                 "sqlhelper_db_conf.yml"),
           exclusive=TRUE)
@@ -153,6 +157,7 @@ test_that("defaults are properly set", {
 })
 
 test_that("correct connections are used for interpolation",{
+  skip_if_not_installed("RSQLite")
   skip("Requires local SQL Server instance") # comment if local
   foo <- "noo"
   bar <- "baz"
@@ -190,6 +195,7 @@ test_that("correct connections are used for interpolation",{
 
 # interpolation is correct
 test_that("interpolation is correct", {
+  skip_if_not_installed("RSQLite")
 
   # connection specified in comment is bad
   expect_error(

--- a/tests/testthat/test-set_default_conn_name.R
+++ b/tests/testthat/test-set_default_conn_name.R
@@ -1,4 +1,5 @@
 test_that("get returns the default default", {
+  skip_if_not_installed("RSQLite")
   connect(config_filename = testthat::test_path("testfiles",
                                                 "sqlhelper_db_conf.yml"),
           exclusive=TRUE)
@@ -7,10 +8,12 @@ test_that("get returns the default default", {
 })
 
 test_that("set errors if no known connection is named", {
+  skip_if_not_installed("RSQLite")
   expect_error(set_default_conn_name("foo"))
 })
 
 test_that("set changes the default connection", {
+  skip_if_not_installed("RSQLite")
   set_default_conn_name("pool_mem")
   expect_equal(get_default_conn_name(), "pool_mem")
   expect_true(connection_info("pool_mem")$default)

--- a/tests/testthat/test-sqlrunners.R
+++ b/tests/testthat/test-sqlrunners.R
@@ -1,4 +1,5 @@
 test_that("runqueries runs queries in sequence", {
+  skip_if_not_installed("RSQLite")
   connect( testthat::test_path("testfiles",
                                "sqlhelper_db_conf.yml"),
            exclusive = TRUE)
@@ -21,6 +22,7 @@ test_that("runqueries runs queries in sequence", {
 })
 
 test_that("runfiles runs files", {
+  skip_if_not_installed("RSQLite")
   results <- runfiles(
     c(
       testthat::test_path("testfiles",
@@ -40,6 +42,7 @@ test_that("runfiles runs files", {
 
 # test quoting
 test_that("quotesql works",{
+  skip_if_not_installed("RSQLite")
   species <- "'setosa'; DROP TABLE IRIS;"
   result <- runqueries(c(injection="SELECT * FROM IRIS WHERE species LIKE {species}",
                          survived="SELECT * FROM SQLITE_SCHEMA WHERE type='table' AND name='iris'"))
@@ -55,6 +58,8 @@ test_that("quotesql works",{
 
 ## Spatial read (geometry)
 test_that("spatial read works", {
+  skip_if_not_installed("RSQLite")
+  skip_if_not_installed("spData")
 
   sf::st_write(spData::congruent, default_conn(), "congruent")
 
@@ -94,6 +99,8 @@ test_that("spatial read works", {
 ## send-bind-fetch
 
 test_that("send-bind-fetch works", {
+  skip_if_not_installed("RSQLite")
+  skip_if_not_installed("dplyr")
   # Send-bind-fetch doesn't work with pool connections:
   # http://rstudio.github.io/pool/reference/DBI-custom.html
 
@@ -127,6 +134,7 @@ test_that("send-bind-fetch works", {
 
 # test connection
 test_that("correct connections are used", {
+  skip_if_not_installed("RSQLite")
   runqueries("DROP TABLE iris",execmethod="execute")
 
   iris_char <- iris
@@ -219,6 +227,7 @@ test_that("correct connections are used", {
 
 # test interpolate
 test_that("interpolation can be turned off", {
+  skip_if_not_installed("RSQLite")
 
   n <- 5
   expect_equal(runqueries("select {n} as 'n'"), data.frame(n))
@@ -252,6 +261,7 @@ test_that("interpolation can be turned off", {
 
 # test include_params
 test_that("parameters can be included when required", {
+  skip_if_not_installed("RSQLite")
 
   expect_equal(runqueries("select 1 as 'n'", include_params = TRUE),
                tibble::tibble(qname = as.character(NA),


### PR DESCRIPTION
## Summary

Fixes noSuggests check failures (https://www.stats.ox.ac.uk/pub/bdr/noSuggests/sqlhelper.out).

- Examples now use `@examplesIf` to skip when RSQLite/spData are not installed
- All `test_that` blocks that depend on SQLite connections have `skip_if_not_installed("RSQLite")` guards
- Additional guards for `spData` and `dplyr` where needed
- Re-documented with roxygen2 7.3.3

## Test plan

- [ ] R-CMD-check action passes across all matrix platforms
- [ ] Local `devtools::check(env_vars = c("_R_CHECK_FORCE_SUGGESTS_" = "false"))` passes with 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)